### PR TITLE
change readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Renders [Wikimedia-style links](https://www.mediawiki.org/wiki/Help:Links#Intern
 Install this into your project:
 
 ```bash
-npm --save install markdown-it-wikilinks
+npm --save install @gerhobbelt/markdown-it-wikilinks
 ```
 
 ...and *use* it:
 
 ```js
-const wikilinks = require('markdown-it-wikilinks');
+const wikilinks = require('@gerhobbelt/markdown-it-wikilinks');
 const options = ...;
 const md = require('markdown-it')()
     .use(wikilinks, options);


### PR DESCRIPTION
hey, guy! You should change your README. In this way, people can install your npm package normally after reading the README.
In addition, your npm "Homepage" and "Repository" should also be modified.

It should be modified to `https://github.com/GerHobbelt/markdown-it-wikilinks#readme`

![image](https://user-images.githubusercontent.com/45024266/103186447-8af16880-48fb-11eb-81e2-32963155c538.png)

![image](https://user-images.githubusercontent.com/45024266/103186492-aa889100-48fb-11eb-957c-80563b4ba675.png)

Also, these two buttons should also be replaced or deleted. They point to the address of the original author, not to your npm package.

[![Coverage Status](https://coveralls.io/repos/github/jsepia/markdown-it-wikilinks/badge.svg?branch=master)](https://coveralls.io/github/jsepia/markdown-it-wikilinks?branch=master)

[![Build Status](https://travis-ci.org/jsepia/markdown-it-wikilinks.svg?branch=master)](https://travis-ci.org/jsepia/markdown-it-wikilinks) 

```txt
[![Coverage Status](https://coveralls.io/repos/github/jsepia/markdown-it-wikilinks/badge.svg?branch=master)](https://coveralls.io/github/jsepia/markdown-it-wikilinks?branch=master)

[![Build Status](https://travis-ci.org/jsepia/markdown-it-wikilinks.svg?branch=master)](https://travis-ci.org/jsepia/markdown-it-wikilinks) 
```
